### PR TITLE
Add a filter for $load_scripts in enqueue_scripts()

### DIFF
--- a/buddymeet.php
+++ b/buddymeet.php
@@ -208,6 +208,8 @@ class BuddyMeet {
                 }
             }
         }
+	    
+        $load_scripts = apply_filters( 'buddymeet_enqueue_scripts_load_scripts', $load_scripts );
 
         if($load_scripts){
             wp_enqueue_script('jquery-ui-autocomplete');


### PR DESCRIPTION
This commit adds a filter for setting the value of $load_scripts in enqueue_scripts().


#### Personal usage example: calling buddymeet from a custom shortcode
I have a `[custom-shortcode]` which calls `do_shortcode('[buddymeet room=example]')`. In the current version it doesn't work, because $load_scripts get falsy, so the scripts aren't loaded. Using this new filter, it could be resolved with  the following.

```php
add_filter( 'buddymeet_enqueue_scripts_load_scripts', 'set_buddymeet_load_scripts' );
                                                                                                                                                                                            
function set_buddymeet_load_scripts($load_scripts) {
        if ( is_page() || is_single() ) {
                $post = get_post();
                if ( $post && has_shortcode( $post->post_content, 'custom-shortcode' ) ) {
                        $load_scripts = true;
                }
        }

        return $load_scripts;
}           
```
I'm mentioning this usage because I saw other people have been trying to do this with no success, but there are other possible usages for this filter, sure.